### PR TITLE
Adding /work /input /state /output directories and making the work di…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,6 @@ RUN apt update --fix-missing && \
 
 RUN mkdir -p /working/software
 RUN mkdir -p /working/software/pip
-RUN mkdir -p /working/data
-RUN mkdir -p /working/data/state
-RUN mkdir -p /working/data/work
-RUN mkdir -p /working/data/input
-RUN mkdir -p /working/data/output
 
 FROM base AS prerequirements
 
@@ -43,6 +38,11 @@ COPY ./workflows /working/software/workflows
 RUN cp /working/software/workflows/luigi.cfg.template /working/software/workflows/luigi.cfg
 RUN chmod +x /working/software/workflows/cloudmask/container/exec.sh
 
-WORKDIR /working
+RUN mkdir -p /input
+RUN mkdir -p /work
+RUN mkdir -p /state
+RUN mkdir -p /output
+
+WORKDIR /work
 
 ENTRYPOINT [ "/working/software/workflows/cloudmask/container/exec.sh" ]

--- a/workflows/cloudmask/container/exec.sh
+++ b/workflows/cloudmask/container/exec.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
 umask 002
-cd /working/software/workflows
+# cd /working/software/workflows
 
 export GDAL_DRIVER_PATH="/usr/lib/x86_64-linux-gnu/gdalplugins"
 export GDAL_DATA="/usr/share/gdal"
 export PROJ_DATA="/usr/local/share/proj"
 export TMPDIR="/tmp"
 
-PYTHONPATH='.' luigi "$@"
+PYTHONPATH='/working/software/workflows' luigi "$@"


### PR DESCRIPTION
…rectory /work and updating the PYTHONPATH variable in the exec script, this allows us to mount to the working directories in apptainer builds preventing writing to the current working directory by rios / python-fmask