### PR TITLE
Allow output file overwrites on JASMIN

### DIFF
--- a/scripts/ard_cloudmasks.py
+++ b/scripts/ard_cloudmasks.py
@@ -158,7 +158,7 @@ def create_output_files(file_mappings, symlink):
                 os.symlink(esa_filepath, ard_filepath)
             else:
                 logging.info(f"Copying file from {ard_filepath} to {esa_filepath}")
-                shutil.copy(esa_filepath, ard_filepath)
+                shutil.copyfile(esa_filepath, ard_filepath)
         else:
             logging.info(f"Skipping output creation for {esa_filepath}, no matching ARD was found")
 

--- a/workflows/cloudmask/MoveOutputFilesToFinalPath.py
+++ b/workflows/cloudmask/MoveOutputFilesToFinalPath.py
@@ -39,7 +39,7 @@ class MoveOutputFilesToFinalPath(luigi.Task):
         outputImagePath.mkdir(parents=True, exist_ok=True)
         
         logging.info(f'Copying temporary output combined cloud and shadow mask to {outputImagePath.joinpath(cloudmask.name)}')
-        shutil.copy(cloudmask, f'{outputImagePath.joinpath(cloudmask.name)}')
+        shutil.copyfile(cloudmask, f'{outputImagePath.joinpath(cloudmask.name)}')
         output['outputs']['combinedCloudAndShadowMask'] = f'{outputImagePath.joinpath(cloudmask.name)}'
         
         if self.reproject and self.reprojectionEPSG:
@@ -49,7 +49,7 @@ class MoveOutputFilesToFinalPath(luigi.Task):
             outputImagePath.mkdir(parents=True, exist_ok=True)
 
             logging.info(f'Copying temporary reprojected output combined cloud and shadow mask to {outputImagePath.joinpath(cloudmask.name.replace('final_', ''))}')
-            shutil.copy(cloudmask, f'{outputImagePath.joinpath(cloudmask.name.replace('final_', ''))}')
+            shutil.copyfile(cloudmask, f'{outputImagePath.joinpath(cloudmask.name.replace('final_', ''))}')
             output['outputs']['reprojectedCombinedCloudAndShadowMask']  = f'{outputImagePath.joinpath(cloudmask.name)}'
 
         with self.output().open('w') as o:


### PR DESCRIPTION
shutil.copy tries to overwrite the file permissions which JASMIN doesn't allow if it belongs to another user, so use shutil.copyfile to just replace the file contents. 